### PR TITLE
Add -no-color to terraform, avoiding junk like "[32m+·[0m create"

### DIFF
--- a/pipeline/buildspec-apply.yml
+++ b/pipeline/buildspec-apply.yml
@@ -16,12 +16,12 @@ phases:
   build:
     commands:
       - cd $CODEBUILD_SRC_DIR
-      - terraform init -input=false
+      - terraform init -input=false -no-color
       - cd modules/
       - ./python_packages.sh
       - cd $CODEBUILD_SRC_DIR
       - aws s3 cp s3://$PLAN_BUCKET/tfplan tfplan
-      - terraform apply -input=false tfplan
+      - terraform apply -input=false -no-color tfplan
 
   post_build:
     commands:

--- a/pipeline/buildspec-plan.yml
+++ b/pipeline/buildspec-plan.yml
@@ -16,11 +16,11 @@ phases:
   build:
     commands:
       - cd $CODEBUILD_SRC_DIR
-      - terraform init -input=false
+      - terraform init -input=false -no-color
       - cd modules/
       - ./python_packages.sh
       - cd $CODEBUILD_SRC_DIR
-      - terraform plan -var-file=vars/ap_accounts.tfvars -out=tfplan -input=false
+      - terraform plan -var-file=vars/ap_accounts.tfvars -out=tfplan -input=false -no-color
       - aws s3 cp tfplan s3://$PLAN_BUCKET/tfplan
 
   post_build:


### PR DESCRIPTION
When reviewing a 'terraform plan' in the AWS CodeBuild output, it makes it hard to read with all the color code junk:
![Screen Shot 2020-05-27 at 17 44 13](https://user-images.githubusercontent.com/307612/83048581-56ea5800-a039-11ea-9ee4-adff09307c3b.png)
This PR hopefully removes that, using the `-no-color` [option](https://www.terraform.io/docs/commands/init.html) on the init, plan and apply commands.

PR is similar to: https://github.com/ministryofjustice/analytical-platform-iam/pull/158