### PR TITLE
Delete CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @ministryofjustice/analytics-hq


### PR DESCRIPTION
I'm keen to not get notifications about this repo just because of having admin rights to the repo and the devs would probably agree. I suggest that instead, a person writing a PR nominates the most relevant people to review it - it's only a couple of clicks to accept GitHub's suggestions. People can also follow the repo if they wish and be notified for everything.